### PR TITLE
Remove double-marshal on extractAgentAbi

### DIFF
--- a/resources/extractAgentAbi/main.go
+++ b/resources/extractAgentAbi/main.go
@@ -7,14 +7,11 @@ import (
 
 func main() {
 	if rawJson, err := ioutil.ReadFile("resources/blockchain/node_modules/singularitynet-alpha-blockchain/Agent.json"); err == nil {
-		parsedJson := new(interface{})
-		json.Unmarshal(rawJson, parsedJson)
-		agentJson := *parsedJson
-		abi := agentJson.(map[string]interface{})["abi"]
+		parsedJson := make(map[string]interface{})
+		json.Unmarshal(rawJson, &parsedJson)
+		abi := parsedJson["abi"]
 		if abiBytes, err := json.Marshal(abi); err == nil {
-			if rawJson, err = json.Marshal(abi); err == nil {
-				ioutil.WriteFile("resources/Agent.abi", abiBytes, 0644)
-			}
+			ioutil.WriteFile("resources/Agent.abi", abiBytes, 0644)
 		}
 	}
 }


### PR DESCRIPTION
Remove typecast and double-marshal. Tested manually.